### PR TITLE
AndroidManifest.xml now don't force useless attributes

### DIFF
--- a/TwoStageRate/src/main/AndroidManifest.xml
+++ b/TwoStageRate/src/main/AndroidManifest.xml
@@ -1,11 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.morsebyte.shailesh.twostagerating">
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
+<manifest package="com.morsebyte.shailesh.twostagerating">
+    <application/>
 </manifest>

--- a/TwoStageRate/src/main/res/values/strings.xml
+++ b/TwoStageRate/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">TwoStageRating</string>
-</resources>


### PR DESCRIPTION
AndroidManifest.xml in library should be as small as possible without adding unnecessary attributes to XML. I slightly cleaned up library code. 